### PR TITLE
cbac initializor generator

### DIFF
--- a/lib/generators/cbac/copy_files/initializers/cbac_config.rb
+++ b/lib/generators/cbac/copy_files/initializers/cbac_config.rb
@@ -1,2 +1,4 @@
-puts "Initializing Cbac"
-Cbac::Setup.check
+puts "Initializing CBAC..."
+include Cbac
+Cbac::cbac_boot!
+puts "CBAC initialized"


### PR DESCRIPTION
the file now supports the rails 3 iitializors by replacing cbac.check with cbac.cbac_boot!. also added include and ending statement.
