### PR TITLE
CBAC upgrade with Rails 3.1 crashes 

### DIFF
--- a/lib/cbac/cbac_pristine/pristine_permission.rb
+++ b/lib/cbac/cbac_pristine/pristine_permission.rb
@@ -147,7 +147,7 @@ module Cbac
         line_numbers = [line_number]
 
         pristine_file.permissions.each do |permission|
-          line_numbers.push(permission.line_number) if permission.privilege_set_name == self.privilege_set_name && permission.pristine_role_id = self.pristine_role_id && permission.line_number < self.line_number
+          line_numbers.push(permission.line_number) if permission.privilege_set_name == self.privilege_set_name && permission.pristine_role_id == self.pristine_role_id && permission.line_number < self.line_number
         end
 
         line_numbers.each do |number|


### PR DESCRIPTION
When registering changes during, for example, a pristine run, the permission object is accidentally modified, resulting in crashes when looking for the related pristine_role. This patch fixes the comparison to actually be a comparison instead of an assignment.
