### PR TITLE
Fix deprecation warnings on Rails 3.2

### DIFF
--- a/lib/cbac/cbac_pristine/pristine_file.rb
+++ b/lib/cbac/cbac_pristine/pristine_file.rb
@@ -4,7 +4,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), 'pristine_permission'
 module Cbac
   module CbacPristine
     class AbstractPristineFile < ActiveRecord::Base
-      set_table_name "cbac_pristine_files"
+      self.table_name = "cbac_pristine_files"
       attr_accessor :permissions, :generic_roles
       attr_readonly :file_name
 

--- a/lib/cbac/cbac_pristine/pristine_permission.rb
+++ b/lib/cbac/cbac_pristine/pristine_permission.rb
@@ -5,7 +5,7 @@ require 'active_record'
 module Cbac
   module CbacPristine
     class PristinePermission < ActiveRecord::Base
-      set_table_name 'cbac_staged_permissions'
+      self.table_name = 'cbac_staged_permissions'
 
       belongs_to :pristine_role, :class_name => "Cbac::CbacPristine::PristineRole"
       belongs_to :pristine_file, :class_name => "Cbac::CbacPristine::AbstractPristineFile"

--- a/lib/cbac/cbac_pristine/pristine_role.rb
+++ b/lib/cbac/cbac_pristine/pristine_role.rb
@@ -2,7 +2,7 @@ require 'active_record'
 module Cbac
   module CbacPristine
     class PristineRole < ActiveRecord::Base
-      set_table_name "cbac_staged_roles"
+      self.table_name = "cbac_staged_roles"
       attr_readonly :role_type, :role_id, :name
 
       def self.ROLE_TYPES

--- a/lib/cbac/generic_role.rb
+++ b/lib/cbac/generic_role.rb
@@ -1,5 +1,5 @@
 class Cbac::GenericRole < ActiveRecord::Base
-  set_table_name "cbac_generic_roles"
+  self.table_name = "cbac_generic_roles"
   attr_accessible :remarks, :name
 
   has_many :generic_role_members, :class_name => "Cbac::Membership", :foreign_key => "generic_role_id"

--- a/lib/cbac/known_permission.rb
+++ b/lib/cbac/known_permission.rb
@@ -1,5 +1,5 @@
 class Cbac::KnownPermission < ActiveRecord::Base
-  set_table_name "cbac_known_permissions"
+  self.table_name = "cbac_known_permissions"
   attr_readonly :permission_type, :permission_number
 
   cattr_accessor :PERMISSION_TYPES

--- a/lib/cbac/membership.rb
+++ b/lib/cbac/membership.rb
@@ -1,4 +1,4 @@
 class Cbac::Membership < ActiveRecord::Base
-  set_table_name "cbac_memberships"
+  self.table_name = "cbac_memberships"
   belongs_to :generic_role, :class_name => "Cbac::GenericRole", :foreign_key => "generic_role_id"
 end

--- a/lib/cbac/permission.rb
+++ b/lib/cbac/permission.rb
@@ -1,5 +1,5 @@
 class Cbac::Permission < ActiveRecord::Base
-  set_table_name "cbac_permissions"
+  self.table_name = "cbac_permissions"
 
   belongs_to :generic_role, :class_name => "Cbac::GenericRole", :foreign_key => "generic_role_id"
   belongs_to :privilege_set, :class_name => "Cbac::PrivilegeSetRecord", :foreign_key => "privilege_set_id"

--- a/lib/cbac/privilege_set_record.rb
+++ b/lib/cbac/privilege_set_record.rb
@@ -1,5 +1,5 @@
 class Cbac::PrivilegeSetRecord < ActiveRecord::Base
-  set_table_name "cbac_privilege_set"
+  self.table_name = "cbac_privilege_set"
 
   def set_comment(comment)
     self.comment = comment if has_attribute?("comment")    


### PR DESCRIPTION
ActiveRecord::Base.set_table_name is deprecated in favor of ActiveRecord::Base.table_name= 

This patch changes the calls to set_table_name to no longer cause deprecation warnings on application boot.
