### PR TITLE
Create a CBAC version to use with Rails 5

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+Copyright &copy; 2009 Bert Meerman
+
+* * *
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Context Based Access Control _(cbac)_
+
+> Easy to use, light-weight authorization system for Rails applications.
+
+Context Based Access Control allows you to build a Rails application with both generic roles as well as context roles. The generic role part allows an application to authorize users with a conventional role system. The context part allows an application to authorize with a combination of the user credentials and the context of the requested action.
+
+## Install
+The gem can be installed using the 'gem' command: `gem install cbac`
+
+Please use the correct version of _cbac_ in your `Gemfile`:
+- for Rails 3 and lower: `gem 'cbac', '~> 0.6.10'`
+- for Rails 4: `gem 'cbac', '~> 0.7.0'`
+- for Rails 5: `gem 'cbac', '~> 0.8.0'`
+
+## Usage
+To use the gem, see the documentation at cbac.rubyforge.org.
+
+## License
+This project is licensed under the MIT License. See the LICENSE.md file for details.

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,34 +1,23 @@
-= Context Based Access Control
+= Context Based Access Control (cbac)
 
-== DESCRIPTION:
-Easy to use, light-weight authorization system for Rails applications.
+== Description
+<em>Easy to use, light-weight authorization system for Rails applications.</em>
 
-== Update
-Version 0.7 contains several updates on the system. This is driven by the
-wish to be compliant with Rails 4.2, the oldest Rails version that is
-currently under support.
+Context Based Access Control allows you to build a Rails application with both generic roles as well as context roles. The generic role part allows an application to authorize users with a conventional role system. The context part allows an application to authorize with a combination of the user credentials and the context of the requested action.
 
-== FEATURES:
-- Authorize users via roles/ groups
-- Authorize users via the context of their request
+== Install
+The gem can be installed using the 'gem' command: <code>gem install cbac</code>
 
-== SYNOPSIS:
-Context Based Access Control allows you to build a Rails application with
-both generic roles as well as context roles. The generic role part allows
-an application to authorize users with a conventional role system. The context
-part allows an application to authorize with a combination of the user
-credentials and the context of the requested action.
+Please use the correct version of _cbac_ in your *Gemfile*:
+* for Rails 3 and lower: <code>gem 'cbac', '~> 0.6.10'</code>
+* for Rails 4: <code>gem 'cbac', '~> 0.7.0'</code>
+* for Rails 5: <code>gem 'cbac', '~> 0.8.0'</code>
 
-== REQUIREMENTS:
+== Usage
+To use the gem, see the documentation at http://cbac.rubyforge.org.
 
-== INSTALL:
-The gem can be installed using the 'gem' command.
-gem install cbac
-
-To use the gem, see the documentation at cbac.rubyforge.org.
-== LICENSE:
-
-(The MIT License)
+== License
+This project is licensed under the MIT License:
 
 Copyright (c) 2009 Bert Meerman
 

--- a/cbac.gemspec
+++ b/cbac.gemspec
@@ -2,10 +2,10 @@
 
 Gem::Specification.new do |s|
   s.name    = "cbac"
-  s.version = "0.7.0"
+  s.version = "0.8.0"
 
   s.authors                   = ["Bert Meerman"]
-  s.date                      = "2016-08-15"
+  s.date                      = "2018-03-10"
   s.description               = "Simple authorization system for Rails applications. Allows you to develop applications with a mixed role based authorization and a context based authorization model. Does not supply authentication."
   s.email                     = "bertm@rubyforge.org"
   s.files                     = `git ls-files`.split("\n")
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.2.2"
   s.required_rubygems_version = ">= 1.8.11"
   s.rubyforge_project         = "cbac"
-  s.summary                   = "CBAC - Simple authorization system for Rails applications."
+  s.summary                   = "Easy to use, light-weight authorization system for Rails applications."
   s.test_files                = `git ls-files -- test/*.*`.split("\n")
 
   s.add_development_dependency("database_cleaner", "~> 1.5")

--- a/cbac.gemspec
+++ b/cbac.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license                   = "MIT"
   s.rdoc_options              = ["--line-numbers", "--inline-source", "--title", "Cbac", "--main", "README.rdoc"]
   s.require_paths             = ["lib"]
-  s.required_ruby_version     = ">= 1.9.3"
+  s.required_ruby_version     = ">= 2.2.2"
   s.required_rubygems_version = ">= 1.8.11"
   s.rubyforge_project         = "cbac"
   s.summary                   = "CBAC - Simple authorization system for Rails applications."
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec-rails", "~> 3")
   s.add_development_dependency("sqlite3", "~> 1.3")
   s.add_runtime_dependency("echoe", "~> 4")
-  s.add_runtime_dependency("rails", "~> 4.2")
+  s.add_runtime_dependency("rails", "~> 5.0")
 end

--- a/lib/cbac.rb
+++ b/lib/cbac.rb
@@ -121,13 +121,13 @@ module Cbac
       # privilege definitions
       begin
         require File.join(::Rails.root.to_s, "config", "cbac", "privileges.rb")
-      rescue MissingSourceFile
+      rescue LoadError
         puts "CBAC warning: Could not load config/cbac/privileges.rb (Did you run ./script/generate cbac?)"
       end
       # Include context roles file - contains the context role definitions
       begin
         require File.join(::Rails.root.to_s, "config", "cbac", "context_roles.rb")
-      rescue MissingSourceFile
+      rescue LoadError
         puts "CBAC warning: Could not load config/cbac/context_roles.rb (Did you run ./script/generate cbac?)"
       end
 

--- a/lib/cbac/version.rb
+++ b/lib/cbac/version.rb
@@ -1,3 +1,3 @@
 module Cbac
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end

--- a/lib/generators/cbac/copy_files/migrate/create_cbac_from_scratch.rb
+++ b/lib/generators/cbac/copy_files/migrate/create_cbac_from_scratch.rb
@@ -1,4 +1,4 @@
-class CreateCbacFromScratch < ActiveRecord::Migration
+class CreateCbacFromScratch < ActiveRecord::Migration[5.0]
   def self.up
     unless Cbac::Permission.table_exists?
       create_table :cbac_permissions do |t|


### PR DESCRIPTION
This version contains:
- updated dependencies for Rails 5 and Ruby 2.2.2
- new md and rdoc versions of the README and a separate LICENSE file
- use of `LoadError` instead of the deprecated `MissingSourceFile` alias
- versioned migrations as is the default in Rails 5